### PR TITLE
module_loader: exclude python-http-header from SCL http inheritance

### DIFF
--- a/axosyslog_cfg_helper/globals.py
+++ b/axosyslog_cfg_helper/globals.py
@@ -42,5 +42,5 @@ EXCLUSIVE_PLUGINS = {
 # base driver. Use for low-level controls that SCL wrappers provide via
 # their own declared params or that simply don't fit the wrapper's purpose.
 SCL_INHERITANCE_EXCLUDES = {
-    "http": {"azure-auth-header", "cloud-auth"},
+    "http": {"azure-auth-header", "cloud-auth", "python-http-header"},
 }


### PR DESCRIPTION
## Summary
- Add `python-http-header` to `SCL_INHERITANCE_EXCLUDES["http"]` alongside `azure-auth-header` and `cloud-auth`. Same rationale: it is a low-level http plugin that no http-derived SCL wrapper is meant to expose.

## Test plan
- [ ] Regenerate DB and confirm http-derived SCL wrappers no longer surface `python-http-header` as an inherited option.

Assisted-by: Claude:claude-opus-4-7